### PR TITLE
Updated Typo in Linear Doc 

### DIFF
--- a/src/left-nav-title.json
+++ b/src/left-nav-title.json
@@ -153,7 +153,7 @@
     "/docs/test-management/atto/best-practices/": "Best Practices"
   },
   "manage-linear-cycles": {
-    "/docs/test-management/atto/sprint-planner/manage-linear-cycles/": "Manage Liner Cycles"
+    "/docs/test-management/atto/sprint-planner/manage-linear-cycles/": "Manage Linear Cycles"
   },
   "linear": {
     "/docs/test-management/integrations/linear/": "Linear Integration"


### PR DESCRIPTION
Updated Typo in Linear Doc in the left nav bar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the left navigation label: “Manage Liner Cycles” is now “Manage Linear Cycles.”
  * Improves readability and reduces confusion for users navigating the sidebar.
  * No changes to functionality, routing, or other navigation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->